### PR TITLE
Impl local variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/\.cargo/
 /tmp
 /tmp.s
 /tmp.c

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ test: $(COMPILER)
 
 test_all: test
 
+run: tmp
+	$(call RUN_CMD,./tmp)
+
 clean:
 	rm -f tmp.s tmp
 	$(call RUN_CMD,cargo clean)
@@ -44,4 +47,4 @@ fmt:
 	cargo fmt --all
 	cargo clippy --fix --allow-dirty
 
-.PHONY: FORCE test clean test test_all fmt
+.PHONY: FORCE test clean test test_all fmt run

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ tmp.s: tmp.c
 tmp: tmp.s
 	$(call RUN_CMD,$(CC) $(CFLAGS) $(ASFLAGS) $< -o $@)
 
-test: $(COMPILER)
+test:
 	$(call RUN_CMD,cargo test)
 
 test_all: test

--- a/bnf.md
+++ b/bnf.md
@@ -1,6 +1,9 @@
 # Ref
 ```
-expr       = equality
+program    = stmt*
+stmt       = expr ";"
+expr       = assign
+assign     = equality ("=" assign)?
 equality   = relational ("==" relational | "!=" relational)*
 relational = add ("<" add | "<=" add | ">" add | ">=" add)*
 add        = mul ("+" mul | "-" mul)*

--- a/bnf.md
+++ b/bnf.md
@@ -6,5 +6,5 @@ relational = add ("<" add | "<=" add | ">" add | ">=" add)*
 add        = mul ("+" mul | "-" mul)*
 mul        = unary ("*" unary | "/" unary)*
 unary      = ("+" | "-")? primary
-primary    = num | "(" expr ")"
+primary    = num | ident | "(" expr ")"
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     platform: linux/amd64
     volumes:
       - .:/work
+      - ./target:/work/target
+      - ./.cargo/registry:/usr/local/cargo/registry
+      - ./.cargo/git:/usr/local/cargo/git
     working_dir: /work
     tty: true
     stdin_open: true

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1,8 +1,25 @@
-use crate::parser::{BinOpKind, Binary, Expr, ExprKind, UnOp};
+use crate::parser::{
+    BinOpKind, Binary, Expr, ExprKind, Program, ProgramKind, Stmt, StmtKind, UnOp,
+};
 
 pub struct Analyzer {}
 
 impl Analyzer {
+    pub fn down_program(program: Program) -> ConvProgram {
+        let mut conv_program = ConvProgram::new();
+        for stmt in program.into_iter() {
+            match stmt {
+                ProgramKind::Stmt(stmt) => conv_program.push_stmt(Self::down_stmt(stmt)),
+            }
+        }
+        conv_program
+    }
+
+    pub fn down_stmt(stmt: Stmt) -> ConvStmt {
+        match stmt.kind {
+            StmtKind::Expr(expr) => ConvStmt::new_expr(Self::down_expr(expr)),
+        }
+    }
     pub fn down_expr(expr: Expr) -> ConvExpr {
         match expr.kind {
             // `a >= b ` : `b <= a`
@@ -39,12 +56,60 @@ impl Analyzer {
                 ConvExpr::new_num(0),
                 Self::down_expr(*operand),
             ),
+            // do nothing
+            ExprKind::Assign(lhs, rhs) => {
+                ConvExpr::new_assign(Self::down_expr(*lhs), Self::down_expr(*rhs))
+            }
 
             // do nothing
             ExprKind::Unary(UnOp::Plus, operand) => Self::down_expr(*operand),
-            _ => unimplemented!(),
+            ExprKind::Ident(ident) => ConvExpr::new_lvar(ident),
         }
     }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct ConvProgram {
+    pub components: Vec<ConvProgramKind>,
+}
+
+impl ConvProgram {
+    pub fn new() -> Self {
+        Self {
+            components: Vec::new(),
+        }
+    }
+
+    pub fn with_vec(components: Vec<ConvProgramKind>) -> Self {
+        Self { components }
+    }
+
+    pub fn push_stmt(&mut self, stmt: ConvStmt) {
+        self.components.push(ConvProgramKind::Stmt(stmt));
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum ConvProgramKind {
+    Stmt(ConvStmt),
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct ConvStmt {
+    pub kind: ConvStmtKind,
+}
+
+impl ConvStmt {
+    pub fn new_expr(expr: ConvExpr) -> Self {
+        Self {
+            kind: ConvStmtKind::Expr(expr),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum ConvStmtKind {
+    Expr(ConvExpr),
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -63,12 +128,37 @@ impl ConvExpr {
             kind: ConvExprKind::Num(num),
         }
     }
+
+    pub fn new_assign(lhs: ConvExpr, rhs: ConvExpr) -> Self {
+        Self {
+            kind: ConvExprKind::Assign(Box::new(lhs), Box::new(rhs)),
+        }
+    }
+
+    pub fn new_lvar(name: String) -> Self {
+        // FIXME: Currentlty we assume the name is one character and the position in the stackcan be decided by the index of the alphabet.
+        assert!(name.len() == 1);
+        let index = ('a'..='z')
+            .position(|c| c == name.chars().next().unwrap())
+            .expect("Expected alphabet here");
+        let offset = index * 8;
+        Self {
+            kind: ConvExprKind::Lvar(Lvar { offset }),
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ConvExprKind {
     Binary(ConvBinary),
     Num(isize),
+    Lvar(Lvar),
+    Assign(Box<ConvExpr>, Box<ConvExpr>),
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct Lvar {
+    pub offset: usize,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -131,11 +221,24 @@ mod tests {
     fn bin(op: BinOpKind, lhs: Expr, rhs: Expr) -> Expr {
         Expr::new_binary(op, lhs, rhs)
     }
+    fn assign(lhs: Expr, rhs: Expr) -> Expr {
+        Expr::new_assign(lhs, rhs)
+    }
+    fn ident(name: &str) -> Expr {
+        Expr::new_ident(name.to_string())
+    }
     fn conv_num(n: isize) -> ConvExpr {
         ConvExpr::new_num(n)
     }
     fn conv_bin(op: ConvBinOpKind, lhs: ConvExpr, rhs: ConvExpr) -> ConvExpr {
         ConvExpr::new_binary(op, lhs, rhs)
+    }
+
+    fn conv_assign(lhs: ConvExpr, rhs: ConvExpr) -> ConvExpr {
+        ConvExpr::new_assign(lhs, rhs)
+    }
+    fn conv_lvar(name: String) -> ConvExpr {
+        ConvExpr::new_lvar(name)
     }
 
     #[test]
@@ -211,6 +314,35 @@ mod tests {
         let expr = bin(BinOpKind::Ne, num(1), num(2));
         let conv = Analyzer::down_expr(expr);
         let expected = conv_bin(ConvBinOpKind::Ne, conv_num(1), conv_num(2));
+        assert_eq!(conv, expected);
+    }
+
+    #[test]
+    fn test_down_expr_assign() {
+        let expr = assign(ident("a"), num(1));
+        let conv = Analyzer::down_expr(expr);
+        let expected = conv_assign(conv_lvar("a".to_string()), conv_num(1));
+        assert_eq!(conv, expected);
+    }
+
+    #[test]
+    fn test_down_stmt_expr() {
+        let stmt = Stmt::expr(assign(ident("a"), num(1)));
+        let conv = Analyzer::down_stmt(stmt);
+        let expected = ConvStmt::new_expr(conv_assign(conv_lvar("a".to_string()), conv_num(1)));
+        assert_eq!(conv, expected);
+    }
+
+    #[test]
+    fn test_down_program() {
+        let program = Program::with_vec(vec![ProgramKind::Stmt(Stmt::expr(assign(
+            ident("a"),
+            num(1),
+        )))]);
+        let conv = Analyzer::down_program(program);
+        let expected = ConvProgram::with_vec(vec![ConvProgramKind::Stmt(ConvStmt::new_expr(
+            conv_assign(conv_lvar("a".to_string()), conv_num(1)),
+        ))]);
         assert_eq!(conv, expected);
     }
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1,26 +1,38 @@
+use std::collections::BTreeMap;
+
 use crate::parser::{
     BinOpKind, Binary, Expr, ExprKind, Program, ProgramKind, Stmt, StmtKind, UnOp,
 };
 
-pub struct Analyzer {}
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct Analyzer {
+    offset: usize,
+}
 
 impl Analyzer {
-    pub fn down_program(program: Program) -> ConvProgram {
+    pub fn new() -> Self {
+        Self { offset: 0 }
+    }
+
+    pub fn down_program(&mut self, program: Program) -> ConvProgram {
         let mut conv_program = ConvProgram::new();
+        let mut lvar_map = BTreeMap::new();
         for stmt in program.into_iter() {
             match stmt {
-                ProgramKind::Stmt(stmt) => conv_program.push_stmt(Self::down_stmt(stmt)),
+                ProgramKind::Stmt(stmt) => {
+                    conv_program.push_stmt(self.down_stmt(stmt, &mut lvar_map))
+                }
             }
         }
         conv_program
     }
 
-    pub fn down_stmt(stmt: Stmt) -> ConvStmt {
+    pub fn down_stmt(&mut self, stmt: Stmt, lvar_map: &mut BTreeMap<String, usize>) -> ConvStmt {
         match stmt.kind {
-            StmtKind::Expr(expr) => ConvStmt::new_expr(Self::down_expr(expr)),
+            StmtKind::Expr(expr) => ConvStmt::new_expr(self.down_expr(expr, lvar_map)),
         }
     }
-    pub fn down_expr(expr: Expr) -> ConvExpr {
+    pub fn down_expr(&mut self, expr: Expr, lvar_map: &mut BTreeMap<String, usize>) -> ConvExpr {
         match expr.kind {
             // `a >= b ` : `b <= a`
             ExprKind::Binary(Binary {
@@ -29,8 +41,8 @@ impl Analyzer {
                 rhs,
             }) => ConvExpr::new_binary(
                 ConvBinOpKind::Le,
-                Self::down_expr(*rhs),
-                Self::down_expr(*lhs),
+                self.down_expr(*rhs, lvar_map),
+                self.down_expr(*lhs, lvar_map),
             ),
             // `a > b` : `b < a`
             ExprKind::Binary(Binary {
@@ -39,14 +51,14 @@ impl Analyzer {
                 rhs,
             }) => ConvExpr::new_binary(
                 ConvBinOpKind::Lt,
-                Self::down_expr(*rhs),
-                Self::down_expr(*lhs),
+                self.down_expr(*rhs, lvar_map),
+                self.down_expr(*lhs, lvar_map),
             ),
             // do nothing
             ExprKind::Binary(Binary { kind, lhs, rhs }) => ConvExpr::new_binary(
                 ConvBinOpKind::new(kind).unwrap(),
-                Self::down_expr(*lhs),
-                Self::down_expr(*rhs),
+                self.down_expr(*lhs, lvar_map),
+                self.down_expr(*rhs, lvar_map),
             ),
             // do nothing
             ExprKind::Num(n) => ConvExpr::new_num(n),
@@ -54,16 +66,17 @@ impl Analyzer {
             ExprKind::Unary(UnOp::Minus, operand) => ConvExpr::new_binary(
                 ConvBinOpKind::Sub,
                 ConvExpr::new_num(0),
-                Self::down_expr(*operand),
+                self.down_expr(*operand, lvar_map),
             ),
             // do nothing
-            ExprKind::Assign(lhs, rhs) => {
-                ConvExpr::new_assign(Self::down_expr(*lhs), Self::down_expr(*rhs))
-            }
+            ExprKind::Assign(lhs, rhs) => ConvExpr::new_assign(
+                self.down_expr(*lhs, lvar_map),
+                self.down_expr(*rhs, lvar_map),
+            ),
 
             // do nothing
-            ExprKind::Unary(UnOp::Plus, operand) => Self::down_expr(*operand),
-            ExprKind::Ident(ident) => ConvExpr::new_lvar(ident),
+            ExprKind::Unary(UnOp::Plus, operand) => self.down_expr(*operand, lvar_map),
+            ExprKind::Ident(ident) => ConvExpr::new_lvar(ident, &mut self.offset, lvar_map),
         }
     }
 }
@@ -144,13 +157,19 @@ impl ConvExpr {
         }
     }
 
-    pub fn new_lvar(name: String) -> Self {
-        // FIXME: Currentlty we assume the name is one character and the position in the stackcan be decided by the index of the alphabet.
-        assert!(name.len() == 1);
-        let index = ('a'..='z')
-            .position(|c| c == name.chars().next().unwrap())
-            .expect("Expected alphabet here");
-        let offset = index * 8;
+    pub fn new_lvar(
+        name: String,
+        new_offset: &mut usize,
+        lvar_map: &mut BTreeMap<String, usize>,
+    ) -> Self {
+        let offset = match lvar_map.get(&name) {
+            Some(offset) => *offset,
+            None => {
+                *new_offset += 8;
+                lvar_map.insert(name, *new_offset);
+                *new_offset
+            }
+        };
         Self {
             kind: ConvExprKind::Lvar(Lvar { offset }),
         }
@@ -167,6 +186,8 @@ pub enum ConvExprKind {
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Lvar {
+    /// Used like `mov rax, [rbp - offset]` to load the value from the stack.
+    /// note: The stack grows from higher to lower addresses.
     pub offset: usize,
 }
 
@@ -246,21 +267,24 @@ mod tests {
     fn conv_assign(lhs: ConvExpr, rhs: ConvExpr) -> ConvExpr {
         ConvExpr::new_assign(lhs, rhs)
     }
-    fn conv_lvar(name: String) -> ConvExpr {
-        ConvExpr::new_lvar(name)
+
+    fn conv_lvar_with_offset(offset: usize) -> ConvExpr {
+        ConvExpr {
+            kind: ConvExprKind::Lvar(Lvar { offset }),
+        }
     }
 
     #[test]
     fn test_down_expr_num() {
         let expr = num(42);
-        let conv = Analyzer::down_expr(expr);
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
         assert_eq!(conv, conv_num(42));
     }
 
     #[test]
     fn test_down_expr_unary_minus() {
         let expr = unary(UnOp::Minus, num(10));
-        let conv = Analyzer::down_expr(expr);
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
         let expected = conv_bin(ConvBinOpKind::Sub, conv_num(0), conv_num(10));
         assert_eq!(conv, expected);
     }
@@ -268,7 +292,7 @@ mod tests {
     #[test]
     fn test_down_expr_unary_plus() {
         let expr = unary(UnOp::Plus, num(10));
-        let conv = Analyzer::down_expr(expr);
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
         let expected = conv_num(10);
         assert_eq!(conv, expected);
     }
@@ -276,7 +300,7 @@ mod tests {
     #[test]
     fn test_down_expr_binary() {
         let expr = bin(BinOpKind::Add, num(1), num(2));
-        let conv = Analyzer::down_expr(expr);
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
         let expected = conv_bin(ConvBinOpKind::Add, conv_num(1), conv_num(2));
         assert_eq!(conv, expected);
     }
@@ -284,7 +308,7 @@ mod tests {
     #[test]
     fn test_down_expr_nested() {
         let expr = unary(UnOp::Minus, unary(UnOp::Minus, num(5)));
-        let conv = Analyzer::down_expr(expr);
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
         // -(-5) => 0 - (0 - 5)
         let expected = conv_bin(
             ConvBinOpKind::Sub,
@@ -297,7 +321,7 @@ mod tests {
     #[test]
     fn test_down_expr_binary_ge() {
         let expr = bin(BinOpKind::Ge, num(1), num(2));
-        let conv = Analyzer::down_expr(expr);
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
         let expected = conv_bin(ConvBinOpKind::Le, conv_num(2), conv_num(1));
         assert_eq!(conv, expected);
     }
@@ -305,7 +329,7 @@ mod tests {
     #[test]
     fn test_down_expr_binary_gt() {
         let expr = bin(BinOpKind::Gt, num(1), num(2));
-        let conv = Analyzer::down_expr(expr);
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
         let expected = conv_bin(ConvBinOpKind::Lt, conv_num(2), conv_num(1));
         assert_eq!(conv, expected);
     }
@@ -313,7 +337,7 @@ mod tests {
     #[test]
     fn test_down_expr_binary_eq() {
         let expr = bin(BinOpKind::Eq, num(1), num(2));
-        let conv = Analyzer::down_expr(expr);
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
         let expected = conv_bin(ConvBinOpKind::Eq, conv_num(1), conv_num(2));
         assert_eq!(conv, expected);
     }
@@ -321,7 +345,7 @@ mod tests {
     #[test]
     fn test_down_expr_binary_ne() {
         let expr = bin(BinOpKind::Ne, num(1), num(2));
-        let conv = Analyzer::down_expr(expr);
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
         let expected = conv_bin(ConvBinOpKind::Ne, conv_num(1), conv_num(2));
         assert_eq!(conv, expected);
     }
@@ -329,16 +353,16 @@ mod tests {
     #[test]
     fn test_down_expr_assign() {
         let expr = assign(ident("a"), num(1));
-        let conv = Analyzer::down_expr(expr);
-        let expected = conv_assign(conv_lvar("a".to_string()), conv_num(1));
+        let conv = Analyzer::new().down_expr(expr, &mut BTreeMap::new());
+        let expected = conv_assign(conv_lvar_with_offset(8), conv_num(1));
         assert_eq!(conv, expected);
     }
 
     #[test]
     fn test_down_stmt_expr() {
         let stmt = Stmt::expr(assign(ident("a"), num(1)));
-        let conv = Analyzer::down_stmt(stmt);
-        let expected = ConvStmt::new_expr(conv_assign(conv_lvar("a".to_string()), conv_num(1)));
+        let conv = Analyzer::new().down_stmt(stmt, &mut BTreeMap::new());
+        let expected = ConvStmt::new_expr(conv_assign(conv_lvar_with_offset(8), conv_num(1)));
         assert_eq!(conv, expected);
     }
 
@@ -348,10 +372,39 @@ mod tests {
             ident("a"),
             num(1),
         )))]);
-        let conv = Analyzer::down_program(program);
+        let conv = Analyzer::new().down_program(program);
         let expected = ConvProgram::with_vec(vec![ConvProgramKind::Stmt(ConvStmt::new_expr(
-            conv_assign(conv_lvar("a".to_string()), conv_num(1)),
+            conv_assign(conv_lvar_with_offset(8), conv_num(1)),
         ))]);
         assert_eq!(conv, expected);
+    }
+
+    #[test]
+    fn test_local_variable_test() {
+        let mut analyzer = Analyzer::new();
+        let program = Program::with_vec(vec![
+            ProgramKind::Stmt(Stmt::expr(assign(ident("a"), assign(ident("k"), num(1))))),
+            ProgramKind::Stmt(Stmt::expr(assign(ident("c"), num(3)))),
+            ProgramKind::Stmt(Stmt::expr(bin(BinOpKind::Div, ident("a"), ident("k")))),
+        ]);
+        let converted_program = analyzer.down_program(program);
+        assert_eq!(
+            converted_program,
+            ConvProgram::with_vec(vec![
+                ConvProgramKind::Stmt(ConvStmt::new_expr(conv_assign(
+                    conv_lvar_with_offset(8),
+                    conv_assign(conv_lvar_with_offset(16), conv_num(1))
+                ))),
+                ConvProgramKind::Stmt(ConvStmt::new_expr(conv_assign(
+                    conv_lvar_with_offset(24),
+                    conv_num(3)
+                ))),
+                ConvProgramKind::Stmt(ConvStmt::new_expr(conv_bin(
+                    ConvBinOpKind::Div,
+                    conv_lvar_with_offset(8),
+                    conv_lvar_with_offset(16)
+                ))),
+            ])
+        )
     }
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -80,6 +80,7 @@ impl ConvProgram {
         }
     }
 
+    #[allow(dead_code)]
     pub fn with_vec(components: Vec<ConvProgramKind>) -> Self {
         Self { components }
     }
@@ -87,8 +88,12 @@ impl ConvProgram {
     pub fn push_stmt(&mut self, stmt: ConvStmt) {
         self.components.push(ConvProgramKind::Stmt(stmt));
     }
+}
 
-    pub fn into_iter(self) -> impl Iterator<Item = ConvProgramKind> {
+impl IntoIterator for ConvProgram {
+    type Item = ConvProgramKind;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
         self.components.into_iter()
     }
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -42,6 +42,7 @@ impl Analyzer {
 
             // do nothing
             ExprKind::Unary(UnOp::Plus, operand) => Self::down_expr(*operand),
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -87,6 +87,10 @@ impl ConvProgram {
     pub fn push_stmt(&mut self, stmt: ConvStmt) {
         self.components.push(ConvProgramKind::Stmt(stmt));
     }
+
+    pub fn into_iter(self) -> impl Iterator<Item = ConvProgramKind> {
+        self.components.into_iter()
+    }
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -30,7 +30,7 @@ impl Generator {
         for component in program.into_iter() {
             match component {
                 ConvProgramKind::Stmt(stmt) => {
-                    Self::gen_stmt(f, stmt);
+                    Self::gen_stmt(f, stmt)?;
                 }
             }
             writeln!(f, "  pop rax")?;
@@ -50,7 +50,7 @@ impl Generator {
     pub fn gen_stmt<W: Write>(f: &mut BufWriter<W>, stmt: ConvStmt) -> Result<(), std::io::Error> {
         match stmt.kind {
             ConvStmtKind::Expr(expr) => {
-                Self::gen_expr(f, expr);
+                Self::gen_expr(f, expr)?;
             }
         }
         Ok(())
@@ -62,10 +62,10 @@ impl Generator {
                 writeln!(f, "  push {}", num)?;
             }
             ConvExprKind::Binary(binary) => {
-                Self::gen_binary(f, binary);
+                Self::gen_binary(f, binary)?;
             }
             ConvExprKind::Lvar(_) => {
-                Self::gen_lvalue(f, expr);
+                Self::gen_lvalue(f, expr)?;
 
                 writeln!(f, "  pop rax")?;
                 writeln!(f, "  mov rax, [rax]")?; // fetch the value from the address stored in rax

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2,7 +2,7 @@ use std::io::{BufWriter, Write};
 
 use crate::analyzer::{
     ConvBinOpKind, ConvBinary, ConvExpr, ConvExprKind, ConvProgram, ConvProgramKind, ConvStmt,
-    ConvStmtKind,
+    ConvStmtKind, Lvar,
 };
 
 pub struct Generator {}
@@ -64,8 +64,21 @@ impl Generator {
             ConvExprKind::Binary(binary) => {
                 Self::gen_binary(f, binary);
             }
-            ConvExprKind::Lvar(lvar) => todo!(),
-            ConvExprKind::Assign(lhs, rhs) => todo!(),
+            ConvExprKind::Lvar(_) => {
+                Self::gen_lvalue(f, expr);
+
+                writeln!(f, "  pop rax")?;
+                writeln!(f, "  mov rax, [rax]")?; // fetch the value from the address stored in rax
+                writeln!(f, "  push rax")?;
+            }
+            ConvExprKind::Assign(lhs, rhs) => {
+                Self::gen_lvalue(f, *lhs)?;
+                Self::gen_expr(f, *rhs)?;
+                writeln!(f, "  pop rdi")?; // rhs's value
+                writeln!(f, "  pop rax")?; // lhs's address itself
+                writeln!(f, "  mov [rax], rdi")?; // store the rhs's value to the lhs's address
+                writeln!(f, "  push rdi")?; // push the rhs's value back to the stack
+            }
         }
         Ok(())
     }
@@ -117,5 +130,20 @@ impl Generator {
         }
         writeln!(f, "  push rax")?;
         Ok(())
+    }
+
+    // fetch the address of the left-hand side of the assignment
+    pub fn gen_lvalue<W: Write>(
+        f: &mut BufWriter<W>,
+        expr: ConvExpr,
+    ) -> Result<(), std::io::Error> {
+        match expr.kind {
+            ConvExprKind::Lvar(Lvar { offset }) => {
+                writeln!(f, "  mov rax, rbp")?;
+                writeln!(f, "  sub rax, {}", offset)?;
+                writeln!(f, "  push rax")
+            }
+            _ => panic!("Expected Lvar, but got {:?}", expr.kind),
+        }
     }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,6 +1,9 @@
 use std::io::{BufWriter, Write};
 
-use crate::analyzer::{ConvBinOpKind, ConvExpr, ConvExprKind};
+use crate::analyzer::{
+    ConvBinOpKind, ConvBinary, ConvExpr, ConvExprKind, ConvProgram, ConvProgramKind, ConvStmt,
+    ConvStmtKind,
+};
 
 pub struct Generator {}
 
@@ -10,17 +13,46 @@ impl Generator {
         Self {}
     }
 
-    pub fn gen_head<W: Write>(f: &mut BufWriter<W>, expr: ConvExpr) -> Result<(), std::io::Error> {
+    pub fn gen_head<W: Write>(
+        f: &mut BufWriter<W>,
+        program: ConvProgram,
+    ) -> Result<(), std::io::Error> {
         writeln!(f, ".intel_syntax noprefix")?;
         writeln!(f, ".global main")?;
         writeln!(f, "main:")?;
 
-        Self::gen_expr(f, expr)?;
-        writeln!(f, "  pop rax")?;
+        // prologue for the main function frame
+        writeln!(f, "  push rbp")?;
+        writeln!(f, "  mov rbp, rsp")?;
+
+        // TODO: ideally we should count the number of local variables and push them to the stack here.
+        writeln!(f, "  sub rsp, {}", 26 * 8)?; // Reserve space for all possible local variables a-z (each 8 bytes, 26 variables).
+        for component in program.into_iter() {
+            match component {
+                ConvProgramKind::Stmt(stmt) => {
+                    Self::gen_stmt(f, stmt);
+                }
+            }
+            writeln!(f, "  pop rax")?;
+        }
+
+        // epilogue
+        writeln!(f, "  mov rsp, rbp")?;
+        writeln!(f, "  pop rbp")?;
+
         writeln!(f, "  ret")?;
 
         // Specify NX (No eXecute) for the stack
         writeln!(f, ".section .note.GNU-stack,\"\",@progbits")?;
+        Ok(())
+    }
+
+    pub fn gen_stmt<W: Write>(f: &mut BufWriter<W>, stmt: ConvStmt) -> Result<(), std::io::Error> {
+        match stmt.kind {
+            ConvStmtKind::Expr(expr) => {
+                Self::gen_expr(f, expr);
+            }
+        }
         Ok(())
     }
 
@@ -30,51 +62,60 @@ impl Generator {
                 writeln!(f, "  push {}", num)?;
             }
             ConvExprKind::Binary(binary) => {
-                Self::gen_expr(f, *binary.lhs)?;
-                Self::gen_expr(f, *binary.rhs)?;
-                writeln!(f, "  pop rdi")?;
-                writeln!(f, "  pop rax")?;
-                match binary.kind {
-                    ConvBinOpKind::Add => writeln!(f, "  add rax, rdi")?,
-                    ConvBinOpKind::Sub => writeln!(f, "  sub rax, rdi")?,
-                    ConvBinOpKind::Mul => writeln!(f, "  imul rax, rdi")?,
-                    ConvBinOpKind::Div => {
-                        // rdx-rax = rax
-                        writeln!(f, "  cqo")?;
-                        // rax = rdx-rax / rdi
-                        // rdx = rdx-rax % rdi
-                        writeln!(f, "  idiv rdi")?;
-                    }
-                    ConvBinOpKind::Eq => {
-                        writeln!(f, "  cmp rax, rdi")?;
-                        // al : lowwer 8bit of rax
-                        // al = flag-reg(eq)
-                        writeln!(f, "  sete al")?;
-                        writeln!(f, "  movzx rax, al")?;
-                    }
-                    ConvBinOpKind::Ne => {
-                        writeln!(f, "  cmp rax, rdi")?;
-                        // al = flag-reg(not equal to)
-                        writeln!(f, "  setne al")?;
-                        writeln!(f, "  movzx rax, al")?;
-                    }
-                    ConvBinOpKind::Le => {
-                        writeln!(f, "  cmp rax, rdi")?;
-                        // al = flag-reg(less than or equal to)
-                        writeln!(f, "  setle al")?;
-                        writeln!(f, "  movzx rax, al")?;
-                    }
-                    ConvBinOpKind::Lt => {
-                        writeln!(f, "  cmp rax, rdi")?;
-                        // al = flag-reg(less than)
-                        writeln!(f, "  setl al")?;
-                        writeln!(f, "  movzx rax, al")?;
-                    }
-                }
-                writeln!(f, "  push rax")?;
+                Self::gen_binary(f, binary);
             }
-            _ => unimplemented!(),
+            ConvExprKind::Lvar(lvar) => todo!(),
+            ConvExprKind::Assign(lhs, rhs) => todo!(),
         }
+        Ok(())
+    }
+
+    pub fn gen_binary<W: Write>(
+        f: &mut BufWriter<W>,
+        binary: ConvBinary,
+    ) -> Result<(), std::io::Error> {
+        Self::gen_expr(f, *binary.lhs)?;
+        Self::gen_expr(f, *binary.rhs)?;
+        writeln!(f, "  pop rdi")?;
+        writeln!(f, "  pop rax")?;
+        match binary.kind {
+            ConvBinOpKind::Add => writeln!(f, "  add rax, rdi")?,
+            ConvBinOpKind::Sub => writeln!(f, "  sub rax, rdi")?,
+            ConvBinOpKind::Mul => writeln!(f, "  imul rax, rdi")?,
+            ConvBinOpKind::Div => {
+                // rdx-rax = rax
+                writeln!(f, "  cqo")?;
+                // rax = rdx-rax / rdi
+                // rdx = rdx-rax % rdi
+                writeln!(f, "  idiv rdi")?;
+            }
+            ConvBinOpKind::Eq => {
+                writeln!(f, "  cmp rax, rdi")?;
+                // al : lowwer 8bit of rax
+                // al = flag-reg(eq)
+                writeln!(f, "  sete al")?;
+                writeln!(f, "  movzx rax, al")?;
+            }
+            ConvBinOpKind::Ne => {
+                writeln!(f, "  cmp rax, rdi")?;
+                // al = flag-reg(not equal to)
+                writeln!(f, "  setne al")?;
+                writeln!(f, "  movzx rax, al")?;
+            }
+            ConvBinOpKind::Le => {
+                writeln!(f, "  cmp rax, rdi")?;
+                // al = flag-reg(less than or equal to)
+                writeln!(f, "  setle al")?;
+                writeln!(f, "  movzx rax, al")?;
+            }
+            ConvBinOpKind::Lt => {
+                writeln!(f, "  cmp rax, rdi")?;
+                // al = flag-reg(less than)
+                writeln!(f, "  setl al")?;
+                writeln!(f, "  movzx rax, al")?;
+            }
+        }
+        writeln!(f, "  push rax")?;
         Ok(())
     }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -73,6 +73,7 @@ impl Generator {
                 }
                 writeln!(f, "  push rax")?;
             }
+            _ => unimplemented!(),
         }
         Ok(())
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -33,7 +33,6 @@ impl<'a> Lexer<'a> {
                 input = &input[2..];
                 continue;
             }
-
             // skip white spaces
             if input.starts_with(' ') || input.starts_with('\t') {
                 pos.next_char();
@@ -71,6 +70,8 @@ impl<'a> Lexer<'a> {
                 ));
             } else if input.starts_with(';') {
                 tokens.push(Token::new(TokenKind::Semi, pos.next_char()));
+            } else if input.starts_with('=') {
+                tokens.push(Token::new(TokenKind::Eq, pos.next_char()));
             } else if input.starts_with('<') {
                 tokens.push(Token::new(TokenKind::Lt, pos.next_char()));
             } else if input.starts_with('>') {
@@ -169,6 +170,8 @@ pub enum TokenKind {
     EtEq,
     /// Not equal to
     Ne,
+    // assign
+    Eq,
     Eof,
 }
 
@@ -560,6 +563,22 @@ mod tests {
                 TokenKind::Num(1),
                 TokenKind::Ne,
                 TokenKind::Num(2),
+                TokenKind::Eof
+            ]
+        );
+
+        let input = String::from("a = 1");
+        let lexer = Lexer::new(&input);
+        assert_eq!(
+            lexer
+                .tokenize()
+                .into_iter()
+                .map(|token| token.kind())
+                .collect::<Vec<_>>(),
+            token_kinds![
+                TokenKind::Ident("a".to_string()),
+                TokenKind::Eq,
+                TokenKind::Num(1),
                 TokenKind::Eof
             ]
         );

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -97,11 +97,25 @@ impl<'a> Lexer<'a> {
 
                 input = &input[len_token..];
                 continue;
-            } else if input.starts_with(&('a'..='z').collect::<Vec<_>>()[..]) {
+            } else if input
+                .starts_with(&('a'..='z').chain(vec!['_'].into_iter()).collect::<Vec<_>>()[..])
+            {
+                let mut chars = input.chars().peekable();
+                let mut ident = String::from(chars.next().unwrap());
+
+                while let Some(&('a'..='z') | '_') = chars.peek() {
+                    ident.push(chars.next().unwrap());
+                }
+
+                let len_token = ident.len();
+
                 tokens.push(Token::new(
-                    TokenKind::Ident(input.chars().next().unwrap().to_string()),
-                    pos.next_char(),
+                    TokenKind::Ident(ident),
+                    pos.next_token(len_token),
                 ));
+
+                input = &input[len_token..];
+                continue;
             } else {
                 self.error_at(
                     &pos,
@@ -613,6 +627,24 @@ mod tests {
                 TokenKind::Ident("a".to_string()),
                 TokenKind::BinOp(BinOpToken::Mul),
                 TokenKind::Ident("c".to_string()),
+                TokenKind::Eof
+            ]
+        );
+
+        let input = String::from("aa = bb_c =  1");
+        let lexer = Lexer::new(&input);
+        assert_eq!(
+            lexer
+                .tokenize()
+                .into_iter()
+                .map(|token| token.kind())
+                .collect::<Vec<_>>(),
+            token_kinds![
+                TokenKind::Ident("aa".to_string()),
+                TokenKind::Eq,
+                TokenKind::Ident("bb_c".to_string()),
+                TokenKind::Eq,
+                TokenKind::Num(1),
                 TokenKind::Eof
             ]
         );

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -94,6 +94,11 @@ impl<'a> Lexer<'a> {
 
                 input = &input[len_token..];
                 continue;
+            } else if input.starts_with(&('a'..='z').collect::<Vec<_>>()[..]) {
+                tokens.push(Token::new(
+                    TokenKind::Ident(input.chars().next().unwrap().to_string()),
+                    pos.next_char(),
+                ));
             } else {
                 self.error_at(
                     &pos,
@@ -142,6 +147,8 @@ pub enum BinOpToken {
 pub enum TokenKind {
     BinOp(BinOpToken),
     Num(isize),
+    // An identifier
+    Ident(String),
     /// An opening delimiter e.g., `{`
     OpenDelim(DelimToken),
     /// An closing delimiter e.g., `}`
@@ -549,6 +556,36 @@ mod tests {
                 TokenKind::Num(1),
                 TokenKind::Ne,
                 TokenKind::Num(2),
+                TokenKind::Eof
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tokenize_ident() {
+        let input = String::from("a");
+        let lexer = Lexer::new(&input);
+        assert_eq!(
+            lexer
+                .tokenize()
+                .into_iter()
+                .map(|token| token.kind())
+                .collect::<Vec<_>>(),
+            token_kinds![TokenKind::Ident("a".to_string()), TokenKind::Eof]
+        );
+
+        let input = String::from("a * c");
+        let lexer = Lexer::new(&input);
+        assert_eq!(
+            lexer
+                .tokenize()
+                .into_iter()
+                .map(|token| token.kind())
+                .collect::<Vec<_>>(),
+            token_kinds![
+                TokenKind::Ident("a".to_string()),
+                TokenKind::BinOp(BinOpToken::Mul),
+                TokenKind::Ident("c".to_string()),
                 TokenKind::Eof
             ]
         );

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -69,6 +69,8 @@ impl<'a> Lexer<'a> {
                     TokenKind::CloseDelim(DelimToken::Paren),
                     pos.next_char(),
                 ));
+            } else if input.starts_with(';') {
+                tokens.push(Token::new(TokenKind::Semi, pos.next_char()));
             } else if input.starts_with('<') {
                 tokens.push(Token::new(TokenKind::Lt, pos.next_char()));
             } else if input.starts_with('>') {
@@ -153,6 +155,8 @@ pub enum TokenKind {
     OpenDelim(DelimToken),
     /// An closing delimiter e.g., `}`
     CloseDelim(DelimToken),
+    /// semicolon
+    Semi,
     /// Less than
     Lt,
     /// Greater than
@@ -563,7 +567,7 @@ mod tests {
 
     #[test]
     fn test_tokenize_ident() {
-        let input = String::from("a");
+        let input = String::from("a;");
         let lexer = Lexer::new(&input);
         assert_eq!(
             lexer
@@ -571,7 +575,11 @@ mod tests {
                 .into_iter()
                 .map(|token| token.kind())
                 .collect::<Vec<_>>(),
-            token_kinds![TokenKind::Ident("a".to_string()), TokenKind::Eof]
+            token_kinds![
+                TokenKind::Ident("a".to_string()),
+                TokenKind::Semi,
+                TokenKind::Eof
+            ]
         );
 
         let input = String::from("a * c");

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@ fn main() -> Result<(), std::io::Error> {
     let parser = parser::Parser::new();
     let program = parser.parse_program(&mut token_stream);
 
-    let program = analyzer::Analyzer::down_program(program);
+    let mut analyzer = analyzer::Analyzer::new();
+    let program = analyzer.down_program(program);
 
     let mut buf_writer = BufWriter::new(output_file);
     Generator::gen_head(&mut buf_writer, program)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,12 +35,12 @@ fn main() -> Result<(), std::io::Error> {
     let mut token_stream = TokenStream::new(tokens.into_iter(), &input);
 
     let parser = parser::Parser::new();
-    let expr = parser.parse_expr(&mut token_stream);
+    let program = parser.parse_program(&mut token_stream);
 
-    let expr = analyzer::Analyzer::down_expr(expr);
+    let program = analyzer::Analyzer::down_program(program);
 
     let mut buf_writer = BufWriter::new(output_file);
-    Generator::gen_head(&mut buf_writer, expr)?;
+    Generator::gen_head(&mut buf_writer, program)?;
 
     buf_writer.flush()?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -187,6 +187,10 @@ impl Program {
     pub fn push_stmt(&mut self, stmt: Stmt) {
         self.components.push(ProgramKind::Stmt(stmt));
     }
+
+    pub fn into_iter(self) -> impl Iterator<Item = ProgramKind> {
+        self.components.into_iter()
+    }
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -187,8 +187,13 @@ impl Program {
     pub fn push_stmt(&mut self, stmt: Stmt) {
         self.components.push(ProgramKind::Stmt(stmt));
     }
+}
 
-    pub fn into_iter(self) -> impl Iterator<Item = ProgramKind> {
+impl IntoIterator for Program {
+    type Item = ProgramKind;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
         self.components.into_iter()
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,6 +8,28 @@ impl Parser {
         Self {}
     }
 
+    pub fn parse_program<I>(&self, tokens: &mut TokenStream<'_, I>) -> Program
+    where
+        I: Clone + Iterator<Item = Token>,
+    {
+        let mut program = Program::new();
+        while !tokens.at_eof() {
+            program.push_stmt(self.parse_stmt(tokens));
+            tokens.expect(TokenKind::Semi); // stmt must be followed by a semicolon
+        }
+        tokens.expect(TokenKind::Eof);
+        assert!(tokens.next().is_none());
+        program
+    }
+
+    pub fn parse_stmt<I>(&self, tokens: &mut TokenStream<'_, I>) -> Stmt
+    where
+        I: Clone + Iterator<Item = Token>,
+    {
+        let expr = self.parse_expr(tokens);
+        Stmt::expr(expr)
+    }
+
     pub fn parse_expr<I>(&self, tokens: &mut TokenStream<'_, I>) -> Expr
     where
         I: Clone + Iterator<Item = Token>,
@@ -124,6 +146,51 @@ impl Parser {
             None => panic!("No more tokens available in parse_primary"),
         }
     }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct Program {
+    pub components: Vec<ProgramKind>,
+}
+
+impl Program {
+    pub fn new() -> Self {
+        Self {
+            components: Vec::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn with_vec(components: Vec<ProgramKind>) -> Self {
+        Self { components }
+    }
+
+    pub fn push_stmt(&mut self, stmt: Stmt) {
+        self.components.push(ProgramKind::Stmt(stmt));
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum ProgramKind {
+    Stmt(Stmt),
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct Stmt {
+    pub kind: StmtKind,
+}
+
+impl Stmt {
+    pub fn expr(expr: Expr) -> Self {
+        Self {
+            kind: StmtKind::Expr(expr),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum StmtKind {
+    Expr(Expr),
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -303,6 +370,20 @@ mod tests {
         assert_eq!(expr.kind, expected.kind);
     }
 
+    #[test]
+    fn test_parse_stmt() {
+        let input = "1 + 2; 3 + 4;";
+        let tokens = Lexer::new(input).tokenize();
+        let mut token_stream = TokenStream::new(tokens.into_iter(), input);
+        let parser = Parser::new();
+        let program = parser.parse_program(&mut token_stream);
+        let expected = Program::with_vec(vec![
+            stmt(bin(BinOpKind::Add, num(1), num(2))),
+            stmt(bin(BinOpKind::Add, num(3), num(4))),
+        ]);
+        assert_eq!(program, expected);
+    }
+
     fn bin(op: BinOpKind, lhs: Expr, rhs: Expr) -> Expr {
         Expr::new_binary(op, lhs, rhs)
     }
@@ -313,5 +394,9 @@ mod tests {
 
     fn unary(op: UnOp, expr: Expr) -> Expr {
         Expr::new_unary(op, expr)
+    }
+
+    fn stmt(expr: Expr) -> ProgramKind {
+        ProgramKind::Stmt(Stmt::expr(expr))
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,7 +34,25 @@ impl Parser {
     where
         I: Clone + Iterator<Item = Token>,
     {
-        self.parse_equality(tokens)
+        self.parse_assign(tokens)
+    }
+
+    pub fn parse_assign<I>(&self, tokens: &mut TokenStream<'_, I>) -> Expr
+    where
+        I: Clone + Iterator<Item = Token>,
+    {
+        let lhs = self.parse_equality(tokens);
+        let (kind, pos) = match tokens.peek() {
+            Some(Token { kind, pos }) => (kind, pos),
+            None => panic!("Expected token, but none"),
+        };
+        match **kind {
+            TokenKind::Eq => {
+                tokens.next();
+                Expr::new_assign(lhs, self.parse_assign(tokens))
+            }
+            _ => lhs,
+        }
     }
 
     pub fn parse_equality<I>(&self, tokens: &mut TokenStream<'_, I>) -> Expr
@@ -141,6 +159,7 @@ impl Parser {
                     tokens.expect(TokenKind::CloseDelim(DelimToken::Paren));
                     expr
                 }
+                TokenKind::Ident(ident) => Expr::new_ident(ident),
                 _ => panic!("Expected a number, found {:?}", token.kind),
             },
             None => panic!("No more tokens available in parse_primary"),
@@ -203,6 +222,8 @@ pub enum ExprKind {
     Binary(Binary),
     Num(isize),
     Unary(UnOp, Box<Expr>),
+    Assign(Box<Expr>, Box<Expr>),
+    Ident(String),
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -227,6 +248,18 @@ impl Expr {
     pub fn new_unary(kind: UnOp, expr: Expr) -> Self {
         Self {
             kind: ExprKind::Unary(kind, Box::new(expr)),
+        }
+    }
+
+    pub fn new_assign(lhs: Expr, rhs: Expr) -> Self {
+        Self {
+            kind: ExprKind::Assign(Box::new(lhs), Box::new(rhs)),
+        }
+    }
+
+    pub fn new_ident(ident: String) -> Self {
+        Self {
+            kind: ExprKind::Ident(ident),
         }
     }
 }
@@ -384,6 +417,20 @@ mod tests {
         assert_eq!(program, expected);
     }
 
+    #[test]
+    fn test_parse_assign() {
+        let input = "a = 1; b = 3;";
+        let tokens = Lexer::new(input).tokenize();
+        let mut token_stream = TokenStream::new(tokens.into_iter(), input);
+        let parser = Parser::new();
+        let program = parser.parse_program(&mut token_stream);
+        let expected = Program::with_vec(vec![
+            stmt(assign(ident("a"), num(1))),
+            stmt(assign(ident("b"), num(3))),
+        ]);
+        assert_eq!(program, expected);
+    }
+
     fn bin(op: BinOpKind, lhs: Expr, rhs: Expr) -> Expr {
         Expr::new_binary(op, lhs, rhs)
     }
@@ -398,5 +445,13 @@ mod tests {
 
     fn stmt(expr: Expr) -> ProgramKind {
         ProgramKind::Stmt(Stmt::expr(expr))
+    }
+
+    fn assign(lhs: Expr, rhs: Expr) -> Expr {
+        Expr::new_assign(lhs, rhs)
+    }
+
+    fn ident(ident: &str) -> Expr {
+        Expr::new_ident(ident.to_string())
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -51,46 +51,46 @@ fn assert_case(expected: i32, input: &str) {
 
 #[test]
 fn test_literals_and_arithmetic() {
-    assert_case(1, "1");
-    assert_case(0, "0");
-    assert_case(255, "255");
-    assert_case(1, "1 + 0");
-    assert_case(2, "1 + 1");
-    assert_case(97, "1 + 100 - 4");
-    assert_case(4, "1 * 2 + 8 / 4");
-    assert_case(6, "1 * 2 + 2 *8 / 4");
-    assert_case(97, "1 * 2 - 2 *8 / 4 + 99");
-    assert_case(99, "1 * (2 - 2) *8 / 4 + 99");
-    assert_case(5, "(1 - 2) * (0 - 8) - 3*1");
-    assert_case(10, "-10 + 20");
-    assert_case(10, "- -10");
-    assert_case(10, "- - +10");
+    assert_case(1, "1;");
+    assert_case(0, "0;");
+    assert_case(255, "255;");
+    assert_case(1, "1 + 0;");
+    assert_case(2, "1 + 1;");
+    assert_case(97, "1 + 100 - 4;");
+    assert_case(4, "1 * 2 + 8 / 4;");
+    assert_case(6, "1 * 2 + 2 *8 / 4;");
+    assert_case(97, "1 * 2 - 2 *8 / 4 + 99;");
+    assert_case(99, "1 * (2 - 2) *8 / 4 + 99;");
+    assert_case(5, "(1 - 2) * (0 - 8) - 3*1;");
+    assert_case(10, "-10 + 20;");
+    assert_case(10, "- -10;");
+    assert_case(10, "- - +10;");
 }
 
 #[test]
 fn test_comparisons() {
-    assert_case(1, "1 == 1");
-    assert_case(0, "1 != 1");
-    assert_case(0, "1 > 2");
-    assert_case(1, "2 > 1");
-    assert_case(1, "1 < 2");
-    assert_case(0, "1 < 1");
-    assert_case(1, "1 <= 2");
-    assert_case(1, "1 <= 1");
-    assert_case(0, "1 >= 2");
-    assert_case(1, "1 >= 1");
-    assert_case(0, "1 > 1");
+    assert_case(1, "1 == 1;");
+    assert_case(0, "1 != 1;");
+    assert_case(0, "1 > 2;");
+    assert_case(1, "2 > 1;");
+    assert_case(1, "1 < 2;");
+    assert_case(0, "1 < 1;");
+    assert_case(1, "1 <= 2;");
+    assert_case(1, "1 <= 1;");
+    assert_case(0, "1 >= 2;");
+    assert_case(1, "1 >= 1;");
+    assert_case(0, "1 > 1;");
 }
 
 #[test]
 fn test_comparison_chains() {
-    assert_case(1, "1 == 1");
-    assert_case(0, "1 != 1");
-    assert_case(0, "(1 == 1) < (1 != 1)");
-    assert_case(1, "1 == 1 < 1 != 1");
-    assert_case(1, "2 >= 2");
+    assert_case(1, "1 == 1;");
+    assert_case(0, "1 != 1;");
+    assert_case(0, "(1 == 1) < (1 != 1);");
+    assert_case(1, "1 == 1 < 1 != 1;");
+    assert_case(1, "2 >= 2;");
     assert_case(
         100,
-        "((32 + -980) <= (-  5*4 * (-2) + 9 -997 * (-2) / (-2))) + 99",
+        "((32 + -980) <= (-  5*4 * (-2) + 9 -997 * (-2) / (-2))) + 99;",
     );
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -104,4 +104,5 @@ fn test_assignments() {
         55,
         "a = 1; b = 2; c = 3; z = 4; y = 5; x = 6; t = 10; u = 9; v = 8; w = 7; a +  b + c + z + y + x + t + u + v + w;",
     );
+    assert_case(3, "abc = 22; cde=7; abc / cde;");
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -94,3 +94,14 @@ fn test_comparison_chains() {
         "((32 + -980) <= (-  5*4 * (-2) + 9 -997 * (-2) / (-2))) + 99;",
     );
 }
+
+#[test]
+fn test_assignments() {
+    assert_case(1, "a = 1; a;");
+    assert_case(2, "a = 1; a = 2; a;");
+    assert_case(3, "a = 1; a = a + 2; a;");
+    assert_case(
+        55,
+        "a = 1; b = 2; c = 3; z = 4; y = 5; x = 6; t = 10; u = 9; v = 8; w = 7; a +  b + c + z + y + x + t + u + v + w;",
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds identifiers/assignments and multi-statement programs with stack-based local variables, updating lexer/parser/analyzer/codegen and tests.
> 
> - **Language/Grammar**:
>   - Support `program` of `stmt` terminated by `;`.
>   - Add `assign` (`=`) with right-associativity; introduce `ident` in `primary`.
> - **Lexer**:
>   - Tokenize `Ident`, `Semi`, and `Eq` (`=`); adjust number scan; tests added.
> - **Parser**:
>   - New AST: `Program`, `Stmt`; parse `program`, `stmt`, `assign`, and `ident`.
>   - Existing precedence preserved; unit tests for statements and assignments.
> - **Analyzer (IR)**:
>   - Convert `Program`/`Stmt`; handle `Assign` and `Ident` as `Lvar` with stack `offset` via map; maintain running offset.
>   - New IR nodes: `ConvProgram`, `ConvStmt`, `Lvar`, `Assign`; tests for locals and nesting.
> - **Codegen**:
>   - Emit function prologue/epilogue; reserve stack space for locals and support lvalues.
>   - Generate code for statements, assignments, identifiers, and extracted binary ops; pop result per stmt.
> - **E2E/Tests**:
>   - All e2e inputs now require `;`; add assignment/local variable cases.
> - **Tooling**:
>   - Makefile adds `run` target; docker-compose caches Cargo; ignore `.cargo/` and test tmp files.
> - **Docs**:
>   - Update `bnf.md` to new grammar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03b8ecbc6ba9a7bf647a2e20af3fb21901188ac1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->